### PR TITLE
Correction for CCS'23 data. Previous data was for Jan cycle only.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Statistics of acceptance rate for the top conferences: Oakland S&P, ACM CCS, USE
 |  Conference   | Acceptance rate  | Paper (accepted/submitted) |
 |  :----  | :----  | :----  |
 | CCS'24  | - | - |
-| CCS'23  | 19.87 | 158/795 |
+| CCS'23  | 19.15% | 235/1222 |
 | CCS'22  |  22.4% | 218/971 |
 | CCS'21  | 22.3% | 196/879  |
 | CCS'20  | 16.9% | 121/715  |


### PR DESCRIPTION
Previous data was Jan CCS 2023 cycle only.
https://dl.acm.org/doi/proceedings/10.1145/3576915